### PR TITLE
n-001

### DIFF
--- a/src/Resource/Document.php
+++ b/src/Resource/Document.php
@@ -209,12 +209,18 @@ class Document extends AbstractResource
 
         foreach ($data['partes'] as $idx => $value) {
             $payload[] = [
-                'name'     => 'partes['.$idx.'][funcao]',
+                'name'     => 'partes[' . $idx . '][funcao]',
                 'contents' => $value['funcao'] ?? null,
             ];
+
+            $typeValueSigner = 'nome';
+            if (array_key_exists('email', $value)) {
+                $typeValueSigner = 'email';
+            }
+
             $payload[] = [
-                'name'     => 'partes['.$idx.'][email]',
-                'contents' => $value['email'] ?? null,
+                'name'     => "partes[" . $idx . "][{$typeValueSigner}]",
+                'contents' => $value[$typeValueSigner] ?? null,
             ];
         }
 


### PR DESCRIPTION
Permitir criar documento apenas com o nome. Isso serve para poder receber o link do documento no retorno.